### PR TITLE
Fixes to backend configuration - IoT & DynamoDB

### DIFF
--- a/cloudformation/backend.template
+++ b/cloudformation/backend.template
@@ -373,6 +373,7 @@
                                     "Action": [
                                         "iot:AddThingToThingGroup",
                                         "iot:CreateThing",
+                                        "iot:CreateThingType",
                                         "iot:CreateThingGroup",
                                         "iot:DescribeThing",
                                         "iot:GetThingShadow",
@@ -530,13 +531,13 @@
             "Properties": {
                 "AttributeDefinitions": [
                     {
-                        "AttributeName": "DetailsId",
+                        "AttributeName": "EndpointId",
                         "AttributeType": "S"
                     }
                 ],
                 "KeySchema": [
                     {
-                        "AttributeName": "DetailsId",
+                        "AttributeName": "EndpointId",
                         "KeyType": "HASH"
                     }
                 ],


### PR DESCRIPTION
Adding required CreateThingType permission to Lambda execution role and aligning key in  SampleEndpointDetails table in DynamoDB table to the expectation in the lambda python scripts.

*Issue #, if available:* - 6
*Description of changes:* Updated the role permissions to include the required CreateThingType permission and updated the SampleEndpointDetails configuration to name the key EndpointId to align it with the python code for the lambda functions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
